### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-activity.yml
+++ b/.github/workflows/update-activity.yml
@@ -5,6 +5,9 @@ on:
     - cron: "*/30 * * * *" # Runs every 30 minutes
   workflow_dispatch: # Allows manual triggering
 
+permissions:
+  contents: write
+
 jobs:
   update-activity:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TheDanniCraft/activity-log/security/code-scanning/1](https://github.com/TheDanniCraft/activity-log/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves committing changes to the repository, it requires `contents: write` permission. Other permissions should be set to `read` or omitted if not needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`update-activity`) to limit its scope. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
