### PR TITLE
🚑 Fix for secrets not allowed to have GITHUB_ prefix

### DIFF
--- a/.github/workflows/update-activity.yml
+++ b/.github/workflows/update-activity.yml
@@ -17,7 +17,7 @@ jobs:
         uses: ./
         with:
           GITHUB_USERNAME: "thedannicraft"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
           EVENT_LIMIT: 10
           OUTPUT_STYLE: MARKDOWN
           IGNORE_EVENTS: "[]"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For a reference example, you can view this [sample `README.md`](https://github.c
 1. Navigate to your GitHub repository.
 2. Go to "Settings" > "Secrets and variables" > "Actions".
 3. Click "New repository secret".
-4. Name the secret (e.g., `GITHUB_TOKEN`).
+4. Name the secret (e.g., `TOKEN`).
 5. Paste the personal access token into the value field.
 6. Click "Add secret".
 
@@ -105,7 +105,7 @@ jobs:
         uses: TheDanniCraft/activity-log@v1
         with:
           GITHUB_USERNAME: "thedannicraft"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Ensure this matches the secret name in repository settings
+          GITHUB_TOKEN: ${{ secrets.TOKEN }} # Ensure this matches the secret name in repository settings
 ```
 
 Take a look at all possible [Inputs](#inputs) for customization
@@ -177,7 +177,7 @@ You can personalize the emojis shown for each event type using the `EVENT_EMOJI_
 uses: TheDanniCraft/activity-log@v1
 with:
   GITHUB_USERNAME: "thedannicraft"
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.TOKEN }}
   EVENT_EMOJI_MAP: |
     PushEvent: "🚀"
     CreateEvent: "✨"


### PR DESCRIPTION
# Pull Request

## 🚀 Description
This pull request updates the usage of the GitHub authentication token from `GITHUB_TOKEN` to `TOKEN` throughout the workflow configuration and documentation. This ensures consistency between the workflow file and the instructions provided in the `README.md`.

Token configuration updates:

* [`.github/workflows/update-activity.yml`](diffhunk://#diff-94a3dd79c130d4b8a771241d200e67e0e03e4e08f9f0d86db9caa8b87009e8d7L20-R20): Changed the workflow input to use `secrets.TOKEN` instead of `secrets.GITHUB_TOKEN`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R81): Updated all references and example usages to instruct users to name the secret `TOKEN` instead of `GITHUB_TOKEN`, including sample workflow snippets and setup instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L81-R81) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L108-R108) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L180-R180)
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)

## 📋 Checklist

<!-- Mark items as complete by putting an `x` in the brackets: [x] -->

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I tested my actions (see [Testing GitHub Actions locally with nektos/act](https://github.com/TheDanniCraft/activity-log/blob/master/CONTRIBUTING.md#test_tube-testing-github-actions-locally-with-nektosact))

## 💬 Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->