### PR TITLE
🐛 Fix update-activity workflow not using correct gitmoji  format

### DIFF
--- a/.github/workflows/update-activity.yml
+++ b/.github/workflows/update-activity.yml
@@ -23,7 +23,7 @@ jobs:
           IGNORE_EVENTS: "[]"
           HIDE_DETAILS_ON_PRIVATE_REPOS: false
           README_PATH: README.md
-          COMMIT_MESSAGE: "⚡ Update README.md with latest activity"
+          COMMIT_MESSAGE: "📝 chore: Update README.md with latest activity"
           EVENT_EMOJI_MAP: |
             PushEvent: "🚀"
             CreateEvent: "✨"
@@ -34,4 +34,3 @@ jobs:
             PullRequestEvent: |
               opened: "🔀"
           DRY_RUN: false
-


### PR DESCRIPTION
# 🚀 Pull Request

## 📝 Description
This pull request makes a minor update to the workflow configuration in `.github/workflows/update-activity.yml`. The main change is an improved commit message for updates to the activity section in the README.

* Updated the `COMMIT_MESSAGE` to "📝 chore: Update README.md with latest activity".
<!-- 
Please include a clear and concise summary of the change and explain the motivation behind it.
If this PR fixes an existing issue, link it here using:
Fixes #(issue_number)
-->

Fixes #(issue)

## 🧩 Type of Change

<!-- 
Mark (x) all the types that apply to this PR.
-->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)  
- [ ] ✨ New feature (non-breaking change that adds functionality)  
- [ ] 💥 Breaking change (change that causes existing functionality to not work as expected)  
- [ ] 🧹 Refactor (code cleanup without changing behavior)  
- [ ] 🧾 Documentation update  
- [ ] 🧪 Tests or CI/CD related  
- [ ] ⚙️ Other (please describe below)

## 📋 Checklist

<!-- Mark items as complete by putting an `x` in the brackets: [x] -->

- [x] I have **read and understood** the [Contribution Guidelines](https://github.com/TheDanniCraft/activity-log/blob/master/CONTRIBUTING.md)  
- [x] My code **follows the project’s coding style**  
- [x] My commit messages follow the [Gitmoji syntax](https://github.com/TheDanniCraft/activity-log/blob/master/CONTRIBUTING.md#tada-using-gitmoji)  
- [x] I have **performed a self-review** of my own code  
- [x] I have **commented** my code where necessary  
- [x] I have **updated documentation** if applicable  
- [x] My changes **generate no new warnings or errors**  
- [x] Any **dependent changes** have been merged and published in downstream modules  
- [ ] I have **tested my actions** locally (see [Testing GitHub Actions with `nektos/act`](https://github.com/TheDanniCraft/activity-log/blob/master/CONTRIBUTING.md#test_tube-testing-github-actions-locally-with-nektosact))  

## 💬 Other Information

<!-- 
Include any additional information such as screenshots, logs, or context that helps reviewers understand this PR.
-->
